### PR TITLE
Fix undefined path fill

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ class SvgUri extends Component {
       case 'path':
         componentAtts = this.obtainComponentAtts(node, PATH_ATTS);
         return (
-          <Path key={i} {...componentAtts} fill={this.props.fill}>
+          <Path key={i} {...componentAtts}>
             {childs}
           </Path>
         );


### PR DESCRIPTION
For some paths the fill was overwritten as `undefined` due to `this.props.fill` being `undefined`. Not sure if the line i've removed is necessary?

Here's an example SVG that wasn't rendering a path fill:

```html
<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
  <path d="M16 27C20.4444 27 24 23.3333 24 19.6667C24 14.1667 20 13.9999 16 5C12 13.9999 8 14.1667 8 19.6667C8 23.3333 11.5556 27 16 27Z" fill="#FDD7DC" stroke="#FC8E87" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
</svg>
```